### PR TITLE
Adds browserify shims for custom version of jQuery and old plugins

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,12 +20,13 @@ gulp.task('templates', function () {
 gulp.task('jquery-plugins', function () {
   return gulp
     .src([
-      //'node_modules/swagger-ui/lib/jquery.ba-bbq.min.js',
+      'node_modules/swagger-ui/lib/jquery-1.8.0.min.js',
+      'node_modules/swagger-ui/lib/jquery.ba-bbq.min.js',
       'node_modules/swagger-ui/lib/jquery.slideto.min.js',
-      'node_modules/swagger-ui/lib/jquery.wiggle.min.js'
+      'node_modules/swagger-ui/lib/jquery.wiggle.min.js',
+      'node_modules/swagger-ui/lib/jsoneditor.min.js'
     ])
-    .pipe(concat('jquery.plugins.js'))
-    .pipe(gulp.dest('./dist'))
+    .pipe(gulp.dest('./dist/lib'))
     .on('error', gutil.log)
 })
 
@@ -56,8 +57,7 @@ gulp.task('wrap-views', ['wrap-files'], function () {
 gulp.task('wrap', ['jquery-plugins', 'wrap-views'], function () {
   return gulp.src([
     './dist/swagger-ui.js',
-    './dist/views.js',
-    './dist/jquery.plugins.js'
+    './dist/views.js'
   ])
     .pipe(concat('index.js'))
     .pipe(replace(/Backbone\.View\.extend\({/g, 'Backbone.View.extend({options: {swaggerOptions: {}},'))

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "backbone": "^1.1.2",
     "handlebars": "^3.0.3",
     "highlight.js": "^7.5.0",
-    "jquery": "^1.9.1",
-    "jquery-bbq": "0.0.3",
+    "jquery": "^2.2.1",
     "marked": "^0.3.5",
     "swagger-client": "^2.1.4",
     "swagger-ui": "2.1.4",
@@ -29,6 +28,7 @@
   },
   "devDependencies": {
     "browserify": "^11.1.0",
+    "browserify-shim": "^3.8.12",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
     "gulp-declare": "^0.3.0",
@@ -37,5 +37,36 @@
     "gulp-util": "^3.0.6",
     "gulp-wrap": "^0.11.0",
     "vinyl-source-stream": "^1.1.0"
+  },
+  "browser": {
+    "jquery1.8": "./dist/lib/jquery-1.8.0.min.js",
+    "jquery-bbq": "./dist/lib/jquery.ba-bbq.min.js",
+    "jquery-slideto": "./dist/lib/jquery.slideto.min.js",
+    "jquery-wiggle": "./dist/lib/jquery.wiggle.min.js",
+    "jsoneditor": "./dist/lib/jsoneditor.min.js"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
+  },
+  "browserify-shim": {
+    "jquery1.8": "$",
+    "jsoneditor": "JSONEditor",
+    "jquery-bbq": {
+      "depends": [
+        "jquery1.8:jQuery"
+      ]
+    },
+    "jquery-slideto": {
+      "depends": [
+        "jquery1.8:jQuery"
+      ]
+    },
+    "jquery-wiggle": {
+      "depends": [
+        "jquery1.8:jQuery"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "gulp",
-    "pre-publish": "gulp"
+    "prepublish": "gulp"
   },
   "author": "",
   "license": "ISC",

--- a/templates/index.txt
+++ b/templates/index.txt
@@ -1,5 +1,7 @@
-var $ = require('jquery')
+var $ = require('jquery1.8')
 require('jquery-bbq')
+require('jquery-slideto')
+require('jquery-wiggle')
 var Backbone = require('backbone')
 Backbone.$ = $
 var Handlebars = require('handlebars')
@@ -7,5 +9,6 @@ var SwaggerClient = require('swagger-client')
 var marked = require('marked')
 var _ = require('underscore')
 var hljs = require('highlight.js')
+var JSONEditor = require('jsoneditor')
 
 <%= contents %>


### PR DESCRIPTION
I wanted at first to wrap jQuery plugins (sldieto and wiggle) with browserify shim but i realised that these old plugins still use $.browser property which has been deleted in jquery 1.9, so I also wrapped jQery 1.8 which comes with swagger-ui. I also wrapped jsoneditor because swagger-ui uses an outdated version of it. It should work now.
