### PR TITLE
Update swagger-ui to 2.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "object-assign": "^4.1.0",
     "sanitize-html": "^1.13.0",
     "swagger-client": "^2.1.4",
-    "swagger-ui": "2.2.3"
+    "swagger-ui": "2.2.10"
   },
   "devDependencies": {
     "browserify": "^11.1.0",


### PR DESCRIPTION
This should resolve a swagger-ui bug that broke resources when tags contain slashes.
https://github.com/swagger-api/swagger-ui/issues/2372
https://github.com/swagger-api/swagger-ui/pull/2558